### PR TITLE
Work around non-writable directories.

### DIFF
--- a/dockerhub2oci
+++ b/dockerhub2oci
@@ -87,4 +87,6 @@ done | aria2c -i - -d ${cachedir} --header="Authorization: Bearer ${token}" -V
 
 for HASHLAYER in ${layers}; do
 	tar --overwrite --exclude=dev/* -C ${imgroot} -xf ${cachedir}/${HASHLAYER}.tar.gz
+        # make sure all directories are owner-writable
+        find ${imgroot} -type d ! -perm -200|xargs -r chmod u+w
 done

--- a/dockerhub2oci
+++ b/dockerhub2oci
@@ -35,7 +35,9 @@ tag="latest"
 
 cachedir=${TMPDIR:-/tmp}/docker2oci/
 
-TEMP=$(getopt -o h --long repo:,image:,tag:,help -n $0 -- "$@")
+writable_dirs=false
+
+TEMP=$(getopt -o h --long repo:,image:,tag:,writable-dirs,help -n $0 -- "$@")
 if [ $? != 0 ] ; then printHelp; exit 1; fi
 eval set -- "$TEMP"
 while true ; do
@@ -44,6 +46,7 @@ while true ; do
 		--image)    image=$2;    shift 2;;
 		--tag)      tag=$2;      shift 2;;
 		--cachedir) cachedir=$2; shift 2;;
+		--writable-dirs) writable_dirs=true; shift 1;;
 		-h|--help)  help;        exit 0;;
 		--)         shift;       break;;
 		*) echo "Internal error!"; exit 1;;
@@ -87,6 +90,8 @@ done | aria2c -i - -d ${cachedir} --header="Authorization: Bearer ${token}" -V
 
 for HASHLAYER in ${layers}; do
 	tar --overwrite --exclude=dev/* -C ${imgroot} -xf ${cachedir}/${HASHLAYER}.tar.gz
-        # make sure all directories are owner-writable
-        find ${imgroot} -type d ! -perm -200|xargs -r chmod u+w
+        if $writable_dirs; then
+                # make sure all directories are owner-writable
+                find ${imgroot} -type d ! -perm -200 -print0|xargs -0 -r chmod u+w
+        fi
 done


### PR DESCRIPTION
@olifre I don't know if you want this or can think of a better way to handle the problem.  I tested with 
```
dockerhub2oci --repo oboberg --image opsim4 --tag 081217
```
(which was the image my user gave me as an example he wanted to extract from dockerhub) and I ran into many unwritable directories.  The patch in this PR worked around the problem.