### PR TITLE
adding blob2oci to simplify action to clean whiteout

### DIFF
--- a/blob2oci
+++ b/blob2oci
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# blob2oci - Simple shell tool to pull from DockerHub and create an OCI image.
+# Copyright (C) 2018 Oliver Freyermuth
+#
+# Contributors
+#  - Vanessa Sochat
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+function help() {
+cat <<EOF
+Tool to extract a layer to a folder of interest, handling whiteout files.
+
+Example usage:
+$0 --layer /path/to/file.tar.gz --extract /extract/here
+EOF
+exit 1
+}
+
+writable_dirs=false
+
+TEMP=$(getopt -o h --long layer:,extract:,help -n $0 -- "$@")
+if [ $? != 0 ] ; then printHelp; exit 1; fi
+eval set -- "$TEMP"
+while true ; do
+	case "$1" in
+		--layer)         layer=$2;           shift 2;;
+                --extract)       extract=$2;         shift 2;;
+		--writable-dirs) writable_dirs=true; shift 1;;
+		-h|--help)       help;               exit 0;;
+		--)              shift;              break;;
+		*) echo "Internal error!";           exit 1;;
+	esac
+done
+
+
+# Checks
+
+if [ ! -f "${layer}" ]; then
+    echo "Cannot find ${layer}"
+    exit 1
+fi
+
+if [ ! -d "${extract}" ]; then
+    echo "Cannot find directory ${extract} to extract."
+    exit 1
+
+else
+
+    # Whiteout handling.
+
+    whiteouts_unchecked=$(tar tf ${layer} --wildcards --wildcards-match-slash ".wh..wh..opq" "*/.wh..wh..opq" ".wh.*" "*/.wh.*" 2>/dev/null)
+
+    # Safety: Check for filenames with newline.
+    num_bad_whiteouts=$(echo -n "${whiteouts_unchecked}" | grep -v '.wh.' | wc -l)
+    if [ ! ${num_bad_whiteouts} -eq 0 ]; then
+        echo "There are ${num_bad_whiteouts} whiteout files with newline characters in the filename in layer ${layer}:"
+        echo "${whiteouts_unchecked}" | grep -v '.wh.'
+        echo "This is likely malicious content, exiting now!"
+        exit 1
+    fi
+
+    whiteouts=$(echo "${whiteouts_unchecked}" | tr '\n' '\0' | xxd -p)
+    opaque_whiteouts=$(echo -n "${whiteouts}" | xxd -p -r | grep -ze '\.wh\.\.wh\.\.opq$' | xxd -p)
+    explicit_whiteouts=$(echo -n "${whiteouts}" | xxd -p -r | grep -zve '\.wh\.\.wh\.\.opq$' | grep -ze '\.wh\.[^/]\+$' | xxd -p)
+
+    # Opaque Whiteouts
+    if [ ! -z "${opaque_whiteouts}" ]; then
+        echo "Warning: Layer ${layer} contains opaque whiteout files:"
+        while IFS= read -r -d '' whiteout_file; do
+	    echo "${whiteout_file}"
+	done < <(echo -n "${opaque_whiteouts}" | xxd -p -r)
+        echo "We do not handle these yet!"
+    fi
+
+    # Explicit Whiteouts
+    if [ ! -z "${explicit_whiteouts}" ]; then
+        while IFS= read -r -d '' whiteout_file; do
+            to_be_deleted=${extract}/$(echo "${whiteout_file}" | sed 's#\.wh\.\([^/]\+\)$#\1#')
+            # Ensure this is below our tree
+            case $(readlink -f "${to_be_deleted}") in $(readlink -f .)/*)
+                rm -rf "${to_be_deleted}";;
+            *)
+                echo "WARNING!";
+                echo "File ${to_be_deleted} is not below extracted tree, skipping!";
+             esac
+         done < <(echo -n "${explicit_whiteouts}" | xxd -p -r)
+    fi 
+    tar --overwrite --exclude=dev/* --exclude=*/.wh.* -C ${extract} -xf ${layer}
+
+    # Make directories owner-writable?
+    if ${writable_dirs}; then
+        find ${extract} -type d ! -perm -200 -print0|xargs -0 -r chmod u+w
+    fi
+fi

--- a/blob2oci
+++ b/blob2oci
@@ -88,6 +88,7 @@ function handle_whiteouts() {
 
             location=$(readlink -f "${to_be_deleted}")
 
+            echo "file:$to_be_deleted --> location:$location";
 
             # If the link isn't within the extraction tree, remove
 

--- a/blob2oci
+++ b/blob2oci
@@ -22,70 +22,6 @@
 ################################################################################
 # Functions
 
-function check_bad_whiteouts() {
-
-    # Look for newline characters in whiteouts, exit if found
-    layer="$1"
-
-    whiteouts_unchecked=$(tar tf ${layer} --wildcards --wildcards-match-slash ".wh..wh..opq" "*/.wh..wh..opq" ".wh.*" "*/.wh.*" 2>/dev/null)
-
-    num_bad_whiteouts=$(echo -n "${whiteouts_unchecked}" | grep -v '.wh.' | wc -l)
-    if [ ! ${num_bad_whiteouts} -eq 0 ]; then
-        echo "There are ${num_bad_whiteouts} whiteout files with newline characters in the filename in layer ${layer}:"
-        echo "${whiteouts_unchecked}" | grep -v '.wh.'
-        echo "This is likely malicious content, exiting now!"
-        exit 1
-    fi
-
-}
-
-function check_opaque_whiteouts() {
-
-    # Return 1 if has opaque, 0 otherwise
-    has_opaque=0
-    layer="$1"
-
-    whiteouts_unchecked=$(tar tf ${layer} --wildcards --wildcards-match-slash ".wh..wh..opq" "*/.wh..wh..opq" ".wh.*" "*/.wh.*" 2>/dev/null)
-    whiteouts=$(echo "${whiteouts_unchecked}" | tr '\n' '\0' | xxd -p)
-    opaque_whiteouts=$(echo -n "${whiteouts}" | xxd -p -r | grep -ze '\.wh\.\.wh\.\.opq$' | xxd -p)
-
-    if [ ! -z "${opaque_whiteouts}" ]; then
-        has_opaque=1
-        echo "Warning: Layer ${layer} contains opaque whiteout files:"
-        while IFS= read -r -d '' whiteout_file; do
-        echo "${whiteout_file}"
-    done < <(echo -n "${opaque_whiteouts}" | xxd -p -r)
-        echo "We do not handle these yet!"
-    fi
-
-    return $has_opaque
-}
-
-
-function remove_explicit_whiteouts() {
-
-    layer="$1"
-
-    whiteouts_unchecked=$(tar tf ${layer} --wildcards --wildcards-match-slash ".wh..wh..opq" "*/.wh..wh..opq" ".wh.*" "*/.wh.*" 2>/dev/null)
-    whiteouts=$(echo "${whiteouts_unchecked}" | tr '\n' '\0' | xxd -p)
-    explicit_whiteouts=$(echo -n "${whiteouts}" | xxd -p -r | grep -zve '\.wh\.\.wh\.\.opq$' | grep -ze '\.wh\.[^/]\+$' | xxd -p)
-
-    if [ ! -z "${explicit_whiteouts}" ]; then
-        while IFS= read -r -d '' whiteout_file; do
-            to_be_deleted=${extract}/$(echo "${whiteout_file}" | sed 's#\.wh\.\([^/]\+\)$#\1#')
-            # Ensure this is below our tree
-            location=$(readlink -f "${to_be_deleted}")
-            case "${location}" in 
-                 # Does being a link imply not below tree?
-                 $(readlink -f .)/*)
-                     rm -rf "${to_be_deleted}";;
-                 *)
-                     echo "WARNING!";
-                     echo "File ${to_be_deleted} is a link (not below extracted tree) skipping!";
-                 esac
-             done < <(echo -n "${explicit_whiteouts}" | xxd -p -r)
-        fi 
-}
 
 function handle_whiteouts() {
 
@@ -114,9 +50,48 @@ function handle_whiteouts() {
 
     # Whiteout handling.
 
-    check_bad_whiteouts "${layer}"
-    check_opaque_whiteouts "${layer}"
-    remove_explicit_whiteouts "${layer}"
+    whiteouts_unchecked=$(tar tf ${layer} --wildcards --wildcards-match-slash ".wh..wh..opq" "*/.wh..wh..opq" ".wh.*" "*/.wh.*" 2>/dev/null)
+    whiteouts=$(echo "${whiteouts_unchecked}" | tr '\n' '\0' | xxd -p)
+
+    num_bad_whiteouts=$(echo -n "${whiteouts_unchecked}" | grep -v '.wh.' | wc -l)
+    if [ ! ${num_bad_whiteouts} -eq 0 ]; then
+        echo "There are ${num_bad_whiteouts} whiteout files with newline characters in the filename in layer ${layer}:"
+        echo "${whiteouts_unchecked}" | grep -v '.wh.'
+        echo "This is likely malicious content, exiting now!"
+        exit 1
+    fi
+
+    # Opaque Whiteouts
+
+    opaque_whiteouts=$(echo -n "${whiteouts}" | xxd -p -r | grep -ze '\.wh\.\.wh\.\.opq$' | xxd -p)
+
+    if [ ! -z "${opaque_whiteouts}" ]; then
+        echo "Warning: Layer ${layer} contains opaque whiteout files:"
+        while IFS= read -r -d '' whiteout_file; do
+        echo "${whiteout_file}"
+    done < <(echo -n "${opaque_whiteouts}" | xxd -p -r)
+        echo "We do not handle these yet!"
+    fi
+
+    # Explicit Whiteouts
+
+    explicit_whiteouts=$(echo -n "${whiteouts}" | xxd -p -r | grep -zve '\.wh\.\.wh\.\.opq$' | grep -ze '\.wh\.[^/]\+$' | xxd -p)
+
+    if [ ! -z "${explicit_whiteouts}" ]; then
+        while IFS= read -r -d '' whiteout_file; do
+            to_be_deleted=${extract}/$(echo "${whiteout_file}" | sed 's#\.wh\.\([^/]\+\)$#\1#')
+            # Ensure this is below our tree
+            location=$(readlink -f "${to_be_deleted}")
+            case "${location}" in 
+                 # Does being a link imply not below tree?
+                 $(readlink -f .)/*)
+                     rm -rf "${to_be_deleted}";;
+                 *)
+                     echo "WARNING!";
+                     echo "File ${to_be_deleted} is a link (not below extracted tree) skipping!";
+                 esac
+             done < <(echo -n "${explicit_whiteouts}" | xxd -p -r)
+        fi 
 
     tar --overwrite --exclude=dev/* --exclude=*/.wh.* -C ${extract} -xf ${layer}
 

--- a/blob2oci
+++ b/blob2oci
@@ -84,22 +84,25 @@ function handle_whiteouts() {
         while IFS= read -r -d '' whiteout_file; do
             to_be_deleted=${extract}/$(echo "${whiteout_file}" | sed 's#\.wh\.\([^/]\+\)$#\1#')
 
-            # Where is the file linking to?
+            # If the directory was already deleted, the file won't exist
+            if [ -e "$to_be_deleted" ]; then
 
-            location=$(readlink -f "${to_be_deleted}")
+                # Where is the file linking to?
 
-            echo "file:$to_be_deleted --> location:$location";
+                location=$(readlink -f "${to_be_deleted}")
 
-            # If the link isn't within the extraction tree, remove
+                echo "file:$to_be_deleted --> location:$location";
 
-            if [[ ${location} ==  ${extract}* ]]; then
-                 echo "File ${to_be_deleted} is in tree, safe to delete.";
-                 rm -rf "${to_be_deleted}";
+                # If the link isn't within the extraction tree, remove
 
-            # Otherwise, could have malicious intent
+                if [[ ${location} ==  ${extract}* ]]; then
+                     rm -rf "${to_be_deleted}";
 
-            else
-                 echo "WARNING: File ${to_be_deleted} links outside of tree. Will not be deleted.";
+                # Otherwise, could have malicious intent
+
+                else
+                     echo "WARNING: File ${to_be_deleted} links outside of tree. Will not be deleted.";
+                fi
             fi
 
         done < <(echo -n "${explicit_whiteouts}" | xxd -p -r)

--- a/blob2oci
+++ b/blob2oci
@@ -6,64 +6,29 @@
 # Contributors
 #  - Vanessa Sochat
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
 
-function help() {
-cat <<EOF
-Tool to extract a layer to a folder of interest, handling whiteout files.
+################################################################################
+# Functions
 
-Example usage:
-$0 --layer /path/to/file.tar.gz --extract /extract/here
-EOF
-exit 1
-}
+function check_bad_whiteouts() {
 
-writable_dirs=false
-
-TEMP=$(getopt -o h --long layer:,extract:,help -n $0 -- "$@")
-if [ $? != 0 ] ; then printHelp; exit 1; fi
-eval set -- "$TEMP"
-while true ; do
-	case "$1" in
-		--layer)         layer=$2;           shift 2;;
-                --extract)       extract=$2;         shift 2;;
-		--writable-dirs) writable_dirs=true; shift 1;;
-		-h|--help)       help;               exit 0;;
-		--)              shift;              break;;
-		*) echo "Internal error!";           exit 1;;
-	esac
-done
-
-
-# Checks
-
-if [ ! -f "${layer}" ]; then
-    echo "Cannot find ${layer}"
-    exit 1
-fi
-
-if [ ! -d "${extract}" ]; then
-    echo "Cannot find directory ${extract} to extract."
-    exit 1
-
-else
-
-    # Whiteout handling.
+    # Look for newline characters in whiteouts, exit if found
+    layer="$1"
 
     whiteouts_unchecked=$(tar tf ${layer} --wildcards --wildcards-match-slash ".wh..wh..opq" "*/.wh..wh..opq" ".wh.*" "*/.wh.*" 2>/dev/null)
 
-    # Safety: Check for filenames with newline.
     num_bad_whiteouts=$(echo -n "${whiteouts_unchecked}" | grep -v '.wh.' | wc -l)
     if [ ! ${num_bad_whiteouts} -eq 0 ]; then
         echo "There are ${num_bad_whiteouts} whiteout files with newline characters in the filename in layer ${layer}:"
@@ -72,36 +37,140 @@ else
         exit 1
     fi
 
+}
+
+function check_opaque_whiteouts() {
+
+    # Return 1 if has opaque, 0 otherwise
+    has_opaque=0
+    layer="$1"
+
+    whiteouts_unchecked=$(tar tf ${layer} --wildcards --wildcards-match-slash ".wh..wh..opq" "*/.wh..wh..opq" ".wh.*" "*/.wh.*" 2>/dev/null)
     whiteouts=$(echo "${whiteouts_unchecked}" | tr '\n' '\0' | xxd -p)
     opaque_whiteouts=$(echo -n "${whiteouts}" | xxd -p -r | grep -ze '\.wh\.\.wh\.\.opq$' | xxd -p)
-    explicit_whiteouts=$(echo -n "${whiteouts}" | xxd -p -r | grep -zve '\.wh\.\.wh\.\.opq$' | grep -ze '\.wh\.[^/]\+$' | xxd -p)
 
-    # Opaque Whiteouts
     if [ ! -z "${opaque_whiteouts}" ]; then
+        has_opaque=1
         echo "Warning: Layer ${layer} contains opaque whiteout files:"
         while IFS= read -r -d '' whiteout_file; do
-	    echo "${whiteout_file}"
-	done < <(echo -n "${opaque_whiteouts}" | xxd -p -r)
+        echo "${whiteout_file}"
+    done < <(echo -n "${opaque_whiteouts}" | xxd -p -r)
         echo "We do not handle these yet!"
     fi
 
-    # Explicit Whiteouts
+    return $has_opaque
+}
+
+
+function remove_explicit_whiteouts() {
+
+    layer="$1"
+
+    whiteouts_unchecked=$(tar tf ${layer} --wildcards --wildcards-match-slash ".wh..wh..opq" "*/.wh..wh..opq" ".wh.*" "*/.wh.*" 2>/dev/null)
+    whiteouts=$(echo "${whiteouts_unchecked}" | tr '\n' '\0' | xxd -p)
+    explicit_whiteouts=$(echo -n "${whiteouts}" | xxd -p -r | grep -zve '\.wh\.\.wh\.\.opq$' | grep -ze '\.wh\.[^/]\+$' | xxd -p)
+
     if [ ! -z "${explicit_whiteouts}" ]; then
         while IFS= read -r -d '' whiteout_file; do
             to_be_deleted=${extract}/$(echo "${whiteout_file}" | sed 's#\.wh\.\([^/]\+\)$#\1#')
             # Ensure this is below our tree
-            case $(readlink -f "${to_be_deleted}") in $(readlink -f .)/*)
-                rm -rf "${to_be_deleted}";;
-            *)
-                echo "WARNING!";
-                echo "File ${to_be_deleted} is not below extracted tree, skipping!";
-             esac
-         done < <(echo -n "${explicit_whiteouts}" | xxd -p -r)
-    fi 
+            location=$(readlink -f "${to_be_deleted}")
+            case "${location}" in 
+                 # Does being a link imply not below tree?
+                 $(readlink -f .)/*)
+                     rm -rf "${to_be_deleted}";;
+                 *)
+                     echo "WARNING!";
+                     echo "File ${to_be_deleted} is a link (not below extracted tree) skipping!";
+                 esac
+             done < <(echo -n "${explicit_whiteouts}" | xxd -p -r)
+        fi 
+}
+
+function handle_whiteouts() {
+
+    # Layer and extract folder required
+
+    if [ "$#" -ne 2 ]; then
+        help;
+        exit 1;
+    fi
+
+    layer="${1}"
+    extract="${2}"
+
+    # Checks
+
+    if [ ! -f "${layer}" ]; then
+        echo "Cannot find ${layer}"
+        exit 1
+    fi
+
+    if [ ! -d "${extract}" ]; then
+        echo "Cannot find directory ${extract} to extract."
+        exit 1
+    fi
+
+
+    # Whiteout handling.
+
+    check_bad_whiteouts "${layer}"
+    check_opaque_whiteouts "${layer}"
+    remove_explicit_whiteouts "${layer}"
+
     tar --overwrite --exclude=dev/* --exclude=*/.wh.* -C ${extract} -xf ${layer}
 
+}
+
+
+################################################################################
+# Main
+
+
+function run_handle_whiteouts() {
+
+    function help() {
+    cat <<EOF
+Tool to extract a layer to a folder of interest, handling whiteout files.
+
+Example usage:
+$0 --layer /path/to/file.tar.gz --extract /extract/here
+EOF
+exit 1
+}
+
+    writable_dirs=false
+
+    # Argument Parsing
+
+    TEMP=$(getopt -o h --long layer:,extract:,help -n $0 -- "$@")
+    if [ $? != 0 ] ; then printHelp; exit 1; fi
+    eval set -- "$TEMP"
+    while true ; do
+        case "$1" in
+            --layer)         layer=$2;           shift 2;;
+            --extract)       extract=$2;         shift 2;;
+            --writable-dirs) writable_dirs=true; shift 1;;
+            -h|--help)       help;               exit 0;;
+            --)              shift;              break;;
+            *) echo "Internal error!";           exit 1;;
+        esac
+    done
+
+    # Main
+
+    handle_whiteouts "${layer}" "${extract}"
+
     # Make directories owner-writable?
+
     if ${writable_dirs}; then
         find ${extract} -type d ! -perm -200 -print0|xargs -0 -r chmod u+w
     fi
+
+}
+
+# If the script has arguments, not being sourced
+
+if [ "$#" -ne 0 ]; then
+    run_handle_whiteouts "$@"
 fi

--- a/blob2oci
+++ b/blob2oci
@@ -51,7 +51,8 @@ function handle_whiteouts() {
     # Whiteout handling.
 
     whiteouts_unchecked=$(tar tf ${layer} --wildcards --wildcards-match-slash ".wh..wh..opq" "*/.wh..wh..opq" ".wh.*" "*/.wh.*" 2>/dev/null)
-    whiteouts=$(echo "${whiteouts_unchecked}" | tr '\n' '\0' | xxd -p)
+
+    # Checking for whiteouts with newline
 
     num_bad_whiteouts=$(echo -n "${whiteouts_unchecked}" | grep -v '.wh.' | wc -l)
     if [ ! ${num_bad_whiteouts} -eq 0 ]; then
@@ -61,9 +62,11 @@ function handle_whiteouts() {
         exit 1
     fi
 
+    whiteouts=$(echo "${whiteouts_unchecked}" | tr '\n' '\0' | xxd -p)
+
     # Opaque Whiteouts
 
-    opaque_whiteouts=$(echo -n "${whiteouts}" | xxd -p -r | grep -ze '\.wh\.\.wh\.\.opq$' | xxd -p)
+    opaque_whiteouts=$(echo -n "${whiteouts_unchecked}" | xxd -p -r | grep -ze '\.wh\.\.wh\.\.opq$' | xxd -p)
 
     if [ ! -z "${opaque_whiteouts}" ]; then
         echo "Warning: Layer ${layer} contains opaque whiteout files:"
@@ -80,18 +83,26 @@ function handle_whiteouts() {
     if [ ! -z "${explicit_whiteouts}" ]; then
         while IFS= read -r -d '' whiteout_file; do
             to_be_deleted=${extract}/$(echo "${whiteout_file}" | sed 's#\.wh\.\([^/]\+\)$#\1#')
-            # Ensure this is below our tree
+
+            # Where is the file linking to?
+
             location=$(readlink -f "${to_be_deleted}")
-            case "${location}" in 
-                 # Does being a link imply not below tree?
-                 $(readlink -f .)/*)
-                     rm -rf "${to_be_deleted}";;
-                 *)
-                     echo "WARNING!";
-                     echo "File ${to_be_deleted} is a link (not below extracted tree) skipping!";
-                 esac
-             done < <(echo -n "${explicit_whiteouts}" | xxd -p -r)
-        fi 
+
+
+            # If the link isn't within the extraction tree, remove
+
+            if [[ ${location} ==  ${extract}* ]]; then
+                 echo "File ${to_be_deleted} is in tree, safe to delete."
+                 rm -rf "${to_be_deleted}";;
+
+            # Otherwise, could have malicious intent
+
+            else
+                 echo "WARNING: File ${to_be_deleted} links outside of tree. Will not be deleted."
+            fi
+
+        done < <(echo -n "${explicit_whiteouts}" | xxd -p -r)
+    fi 
 
     tar --overwrite --exclude=dev/* --exclude=*/.wh.* -C ${extract} -xf ${layer}
 
@@ -148,4 +159,6 @@ exit 1
 
 if [ "$#" -ne 0 ]; then
     run_handle_whiteouts "$@"
+else
+    exec $0 --help
 fi

--- a/blob2oci
+++ b/blob2oci
@@ -92,13 +92,13 @@ function handle_whiteouts() {
             # If the link isn't within the extraction tree, remove
 
             if [[ ${location} ==  ${extract}* ]]; then
-                 echo "File ${to_be_deleted} is in tree, safe to delete."
-                 rm -rf "${to_be_deleted}";;
+                 echo "File ${to_be_deleted} is in tree, safe to delete.";
+                 rm -rf "${to_be_deleted}";
 
             # Otherwise, could have malicious intent
 
             else
-                 echo "WARNING: File ${to_be_deleted} links outside of tree. Will not be deleted."
+                 echo "WARNING: File ${to_be_deleted} links outside of tree. Will not be deleted.";
             fi
 
         done < <(echo -n "${explicit_whiteouts}" | xxd -p -r)

--- a/dockerhub2oci
+++ b/dockerhub2oci
@@ -42,7 +42,7 @@ if [ $? != 0 ] ; then printHelp; exit 1; fi
 eval set -- "$TEMP"
 while true ; do
 	case "$1" in
-		--repo)          repo=$2;            shift 2;;
+        	--repo)          repo=$2;            shift 2;;
                 --registry)      registry=$2;        shift 2;;
 		--image)         image=$2;           shift 2;;
 		--tag)           tag=$2;             shift 2;;

--- a/dockerhub2oci
+++ b/dockerhub2oci
@@ -24,6 +24,9 @@ to a folder to be used as OCI image.
 
 Example usage:
 $0 --repo gliderlabs --image alpine --tag latest
+
+Nvidia Cloud:
+$0 --registry nvcr.io --repo tensorflow --image alpine --tag 17.10 --token $token
 EOF
 exit 1
 }
@@ -37,10 +40,21 @@ if [ ! -f "${HERE}/blob2oci" ]; then
     exit 1 
 fi
 
+# Aria2c
+
+if ! [ -x "$(command -v aria2c)" ]; then
+  echo '# Missing aria2c, install with:
+sudo apt-get install aria2
+sudo yum install aria2
+sudo pacman -Sy aria2' >&2
+  exit 1
+fi
+
 # Defaults
 
 registry="registry.hub.docker.com"
 repo="gliderlabs"
+token="unset"
 image="alpine"
 tag="latest"
 
@@ -58,6 +72,7 @@ while true ; do
 		--tag)           tag=$2;             shift 2;;
 		--cachedir)      cachedir=$2;        shift 2;;
 		--registry)      registry=$2;        shift 2;;
+		--token)         token=$2;           shift 2;;
 		--writable-dirs) writable_dirs=true; shift 1;;
 		-h|--help)       help;               exit 0;;
 		--)              shift;              break;;
@@ -73,16 +88,24 @@ mkdir -p ${imgroot}
 
 img_full="${repo}/${image}"
 
-auth_uri="https://auth.docker.io/token"
-auth_uri_full="${auth_uri}?service=registry.docker.io&scope=repository:${img_full}:pull"
+# If the token is unset, we use default auth_uri and auth_uri full. If a 
+#     different client is needed (e.g., Nvidia Cloud) this logic will be handled
+#     in a calling script, and then token passed forward
+
+if [ "${token}" == "unset" ]; then
+
+    auth_uri="https://auth.docker.io/token"
+    auth_uri_full="${auth_uri}?service=registry.docker.io&scope=repository:${img_full}:pull"
+
+    # If the user is logged in with Docker, this should return the Auth token?
+    token=$(curl -s ${auth_uri_full} | jq -r .token)
+
+    # grep -Po '"'"token"'"\s*:\s*"\K([^"]*)')
+    #echo $token
+fi
 
 reg_uri_manifest="https://${registry}/v2/${img_full}/manifests/${tag}"
 reg_uri_blobs="https://${registry}/v2/${img_full}/blobs"
-
-# Auth token
-token=$(curl -s ${auth_uri_full} | jq -r .token)
-# grep -Po '"'"token"'"\s*:\s*"\K([^"]*)')
-#echo $token
 
 # Layers
 layers_raw=$(curl -s -H "Authorization: Bearer ${token}" "${reg_uri_manifest}" | jq -r .fsLayers[].blobSum)
@@ -94,6 +117,10 @@ layers=$(echo ${layers_raw} | tr ' ' '\n' | tac | uniq)
 # download only fully unique layer IDs.
 layers_dl=$(echo ${layers_raw} | tr ' ' '\n' | sort | uniq)
 
+##############################################
+# Download
+##############################################
+
 for HASHLAYER in ${layers_dl}; do
 	hashtype=${HASHLAYER%:*}
 	layer=${HASHLAYER#*:}
@@ -103,9 +130,19 @@ for HASHLAYER in ${layers_dl}; do
 	echo "  out=${HASHLAYER}.tar.gz"
 done | aria2c -i - -d ${cachedir} --header="Authorization: Bearer ${token}" -V
 
+
+##############################################
+# Extract and Clean
+##############################################
+
 for HASHLAYER in ${layers}; do
 
-        # Call blob2oci to handle the layer
-        exec "${HERE}/blob2oci" --layer "$layer" --extract "${imgroot}" --writable-dirs ${writable_dirs}
+	layer="${cachedir}/${HASHLAYER}.tar.gz"
 
+        # Call blob2oci to handle the layer
+        if [ "${writable_dirs}" == true ]; then
+            exec "${HERE}/blob2oci" --layer "$layer" --extract "${imgroot}" --writable-dirs
+        else
+            exec "${HERE}/blob2oci" --layer "$layer" --extract "${imgroot}"
+        fi
 done

--- a/dockerhub2oci
+++ b/dockerhub2oci
@@ -62,8 +62,14 @@ cachedir=${TMPDIR:-/tmp}/docker2oci/
 
 writable_dirs=false
 
-TEMP=$(getopt -o h --long repo:,image:,tag:,cachedir:,registry:,writable-dirs,help -n $0 -- "$@")
-if [ $? != 0 ] ; then printHelp; exit 1; fi
+# Token can come from environment, second priority to set on command line
+if [ ! -z "${DOCKERHUB2OCI_TOKEN}" ]; then
+    echo "Found token in environment."
+    token=${DOCKERHUB2OCI_TOKEN}; 
+fi
+
+TEMP=$(getopt -o h --long repo:,image:,tag:,cachedir:,registry:,token:,writable-dirs,help -n $0 -- "$@")
+if [ $? != 0 ] ; then usage; exit 1; fi
 eval set -- "$TEMP"
 while true ; do
 	case "$1" in
@@ -106,6 +112,8 @@ fi
 
 reg_uri_manifest="https://${registry}/v2/${img_full}/manifests/${tag}"
 reg_uri_blobs="https://${registry}/v2/${img_full}/blobs"
+
+echo $reg_uri_manifest
 
 # Layers
 layers_raw=$(curl -s -H "Authorization: Bearer ${token}" "${reg_uri_manifest}" | jq -r .fsLayers[].blobSum)

--- a/dockerhub2oci
+++ b/dockerhub2oci
@@ -43,6 +43,7 @@ eval set -- "$TEMP"
 while true ; do
 	case "$1" in
 		--repo)          repo=$2;            shift 2;;
+                --registry)      registry=$2;        shift 2;;
 		--image)         image=$2;           shift 2;;
 		--tag)           tag=$2;             shift 2;;
 		--cachedir)      cachedir=$2;        shift 2;;
@@ -61,8 +62,15 @@ mkdir -p ${imgroot}
 
 img_full="${repo}/${image}"
 
-auth_uri="https://auth.docker.io/token"
-auth_uri_full="${auth_uri}?service=registry.docker.io&scope=repository:${img_full}:pull"
+# Support for nvidia or other (Docker Hub)
+
+if [ "${registry}" == "nvcr.io" ]; then
+    auth_uri="https://authn.nvidia.com/token"
+    auth_uri_full="${auth_uri}?service=registry&scope=repository:${img_full}:pull"
+else
+    auth_uri="https://auth.docker.io/token"
+    auth_uri_full="${auth_uri}?service=registry.docker.io&scope=repository:${img_full}:pull"
+fi
 
 reg_uri_manifest="https://${registry}/v2/${img_full}/manifests/${tag}"
 reg_uri_blobs="https://${registry}/v2/${img_full}/blobs"
@@ -137,3 +145,4 @@ for HASHLAYER in ${layers}; do
 		find ${imgroot} -type d ! -perm -200 -print0|xargs -0 -r chmod u+w
 	fi
 done
+

--- a/dockerhub2oci
+++ b/dockerhub2oci
@@ -1,20 +1,21 @@
 #!/bin/bash
 
+#
 # dockerhub2oci - Simple shell tool to pull from DockerHub and create an OCI image.
 # Copyright (C) 2018  Oliver Freyermuth
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
 
 function help() {
 cat <<EOF
@@ -27,7 +28,17 @@ EOF
 exit 1
 }
 
+# Ensure functions available
+
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ ! -f "${HERE}/blob2oci" ]; then
+    echo "Cannot find blob2oci, exiting."
+    exit 1 
+fi
+
 # Defaults
+
 registry="registry.hub.docker.com"
 repo="gliderlabs"
 image="alpine"
@@ -37,16 +48,16 @@ cachedir=${TMPDIR:-/tmp}/docker2oci/
 
 writable_dirs=false
 
-TEMP=$(getopt -o h --long repo:,image:,tag:,writable-dirs,help -n $0 -- "$@")
+TEMP=$(getopt -o h --long repo:,image:,tag:,cachedir:,registry:,writable-dirs,help -n $0 -- "$@")
 if [ $? != 0 ] ; then printHelp; exit 1; fi
 eval set -- "$TEMP"
 while true ; do
 	case "$1" in
-        	--repo)          repo=$2;            shift 2;;
-                --registry)      registry=$2;        shift 2;;
+		--repo)          repo=$2;            shift 2;;
 		--image)         image=$2;           shift 2;;
 		--tag)           tag=$2;             shift 2;;
 		--cachedir)      cachedir=$2;        shift 2;;
+		--registry)      registry=$2;        shift 2;;
 		--writable-dirs) writable_dirs=true; shift 1;;
 		-h|--help)       help;               exit 0;;
 		--)              shift;              break;;
@@ -62,15 +73,8 @@ mkdir -p ${imgroot}
 
 img_full="${repo}/${image}"
 
-# Support for nvidia or other (Docker Hub)
-
-if [ "${registry}" == "nvcr.io" ]; then
-    auth_uri="https://authn.nvidia.com/token"
-    auth_uri_full="${auth_uri}?service=registry&scope=repository:${img_full}:pull"
-else
-    auth_uri="https://auth.docker.io/token"
-    auth_uri_full="${auth_uri}?service=registry.docker.io&scope=repository:${img_full}:pull"
-fi
+auth_uri="https://auth.docker.io/token"
+auth_uri_full="${auth_uri}?service=registry.docker.io&scope=repository:${img_full}:pull"
 
 reg_uri_manifest="https://${registry}/v2/${img_full}/manifests/${tag}"
 reg_uri_blobs="https://${registry}/v2/${img_full}/blobs"
@@ -100,49 +104,8 @@ for HASHLAYER in ${layers_dl}; do
 done | aria2c -i - -d ${cachedir} --header="Authorization: Bearer ${token}" -V
 
 for HASHLAYER in ${layers}; do
-	# Whiteout handling.
-	whiteouts_unchecked=$(tar tf ${cachedir}/${HASHLAYER}.tar.gz --wildcards --wildcards-match-slash ".wh..wh..opq" "*/.wh..wh..opq" ".wh.*" "*/.wh.*" 2>/dev/null)
 
-	# Safety: Check for filenames with newline.
-	num_bad_whiteouts=$(echo -n "${whiteouts_unchecked}" | grep -v '.wh.' | wc -l)
-	if [ ! ${num_bad_whiteouts} -eq 0 ]; then
-		echo "There are ${num_bad_whiteouts} whiteout files with newline characters in the filename in layer ${HASHLAYER}:"
-		echo "${whiteouts_unchecked}" | grep -v '.wh.'
-		echo "This is likely malicious content, exiting now!"
-		exit 1
-	fi
+        # Call blob2oci to handle the layer
+        exec "${HERE}/blob2oci" --layer "$layer" --extract "${imgroot}" --writable-dirs ${writable_dirs}
 
-	whiteouts=$(echo "${whiteouts_unchecked}" | tr '\n' '\0' | xxd -p)
-
-	opaque_whiteouts=$(echo -n "${whiteouts}" | xxd -p -r | grep -ze '\.wh\.\.wh\.\.opq$' | xxd -p)
-	explicit_whiteouts=$(echo -n "${whiteouts}" | xxd -p -r | grep -zve '\.wh\.\.wh\.\.opq$' | grep -ze '\.wh\.[^/]\+$' | xxd -p)
-
-	if [ ! -z "${opaque_whiteouts}" ]; then
-		echo "Warning: Layer ${HASHLAYER} contains opaque whiteout files:"
-		while IFS= read -r -d '' whiteout_file; do
-			echo "${whiteout_file}"
-		done < <(echo -n "${opaque_whiteouts}" | xxd -p -r)
-		echo "We do not handle these yet!"
-	fi
-	if [ ! -z "${explicit_whiteouts}" ]; then
-		while IFS= read -r -d '' whiteout_file; do
-			to_be_deleted=${imgroot}/$(echo "${whiteout_file}" | sed 's#\.wh\.\([^/]\+\)$#\1#')
-			# Ensure this is below our tree
-			case $(readlink -f "${to_be_deleted}") in
-				$(readlink -f .)/*)
-					rm -rf "${to_be_deleted}";;
-				*)
-					echo "ERROR!";
-					echo "File ${to_be_deleted} is not below extracted tree!";
-					echo "This looks malicious, exiting now!";
-					exit 1;;
-			esac
-		done < <(echo -n "${explicit_whiteouts}" | xxd -p -r)
-	fi
-	tar --overwrite --exclude=dev/* --exclude=*/.wh.* -C ${imgroot} -xf ${cachedir}/${HASHLAYER}.tar.gz
-	if ${writable_dirs}; then
-		# make sure all directories are owner-writable
-		find ${imgroot} -type d ! -perm -200 -print0|xargs -0 -r chmod u+w
-	fi
 done
-

--- a/dockerhub2oci
+++ b/dockerhub2oci
@@ -25,8 +25,14 @@ to a folder to be used as OCI image.
 Example usage:
 $0 --repo gliderlabs --image alpine --tag latest
 
-Nvidia Cloud:
-$0 --registry nvcr.io --repo tensorflow --image alpine --tag 17.10 --token $token
+Options:
+
+--strip-headers: (false) if true, use token for first request and don't forward
+--writable-dirs: (false) if true, make directories writable in blob2oci
+--registry: Docker Hub registry (default registry.hub.docker.com)
+--repo: registry repository (default gliderlabs)
+--image: image name (default alpine)
+--tag: image tag (default latest)
 EOF
 exit 1
 }
@@ -46,7 +52,8 @@ if ! [ -x "$(command -v aria2c)" ]; then
   echo '# Missing aria2c, install with:
 sudo apt-get install aria2
 sudo yum install aria2
-sudo pacman -Sy aria2' >&2
+sudo pacman -Sy aria2
+sudo emerge -av aria2' >&2
   exit 1
 fi
 
@@ -58,8 +65,9 @@ token="unset"
 image="alpine"
 tag="latest"
 
-cachedir=${TMPDIR:-/tmp}/docker2oci/
+cachedir=${TMPDIR:-/tmp}/docker2oci
 
+strip_headers=false
 writable_dirs=false
 
 # Token can come from environment, second priority to set on command line
@@ -68,7 +76,7 @@ if [ ! -z "${DOCKERHUB2OCI_TOKEN}" ]; then
     token=${DOCKERHUB2OCI_TOKEN}; 
 fi
 
-TEMP=$(getopt -o h --long repo:,image:,tag:,cachedir:,registry:,token:,writable-dirs,help -n $0 -- "$@")
+TEMP=$(getopt -o h --long repo:,image:,tag:,cachedir:,registry:,token:,writable-dirs,strip-headers,help -n $0 -- "$@")
 if [ $? != 0 ] ; then usage; exit 1; fi
 eval set -- "$TEMP"
 while true ; do
@@ -80,6 +88,7 @@ while true ; do
 		--registry)      registry=$2;        shift 2;;
 		--token)         token=$2;           shift 2;;
 		--writable-dirs) writable_dirs=true; shift 1;;
+		--strip-headers) strip_headers=true; shift 1;;
 		-h|--help)       help;               exit 0;;
 		--)              shift;              break;;
 		*) echo "Internal error!";           exit 1;;
@@ -113,8 +122,6 @@ fi
 reg_uri_manifest="https://${registry}/v2/${img_full}/manifests/${tag}"
 reg_uri_blobs="https://${registry}/v2/${img_full}/blobs"
 
-echo $reg_uri_manifest
-
 # Layers
 layers_raw=$(curl -s -H "Authorization: Bearer ${token}" "${reg_uri_manifest}" | jq -r .fsLayers[].blobSum)
 # grep -Po '"'"blobSum"'"\s*:\s*"\K([^"]*)')
@@ -125,19 +132,43 @@ layers=$(echo ${layers_raw} | tr ' ' '\n' | tac | uniq)
 # download only fully unique layer IDs.
 layers_dl=$(echo ${layers_raw} | tr ' ' '\n' | sort | uniq)
 
+
 ##############################################
 # Download
 ##############################################
 
-for HASHLAYER in ${layers_dl}; do
-	hashtype=${HASHLAYER%:*}
-	layer=${HASHLAYER#*:}
-	hashtype_aria=$(echo ${hashtype} | sed 's/^\([a-z]*\)\([0-9]*\)$/\1-\2/')
-	echo ${reg_uri_blobs}/${HASHLAYER}
-	echo "  checksum=${hashtype_aria}=${layer}"
-	echo "  out=${HASHLAYER}.tar.gz"
-done | aria2c -i - -d ${cachedir} --header="Authorization: Bearer ${token}" -V
+# The aria2c command that doesn't strip headers is given Auth header directly
 
+echo "Collecting download links..."
+
+if [ "${strip_headers}" == true ]; then
+
+    # Only pass token to first request, use response with aria (without auth)
+    for HASHLAYER in ${layers_dl}; do
+        hashtype=${HASHLAYER%:*}
+        layer=${HASHLAYER#*:}
+        hashtype_aria=$(echo ${hashtype} | sed 's/^\([a-z]*\)\([0-9]*\)$/\1-\2/')
+
+        # Decide on the final uri (with or without Auth, and
+ 	hashlayer_final_uri=${reg_uri_blobs}/${HASHLAYER}
+        hashlayer_final_uri=$(curl -H "Authorization: Bearer ${token}" -Ls -o /dev/null -w %{url_effective} --max-filesize 1024 ${reg_uri_blobs}/${HASHLAYER})
+        echo ${hashlayer_final_uri}
+        echo "  checksum=${hashtype_aria}=${layer}"
+        echo "  out=${HASHLAYER}.tar.gz"
+    done |  aria2c -i - -d ${cachedir} -V
+        
+else
+
+    # Pass Auth header to aria2c and thus all following requests
+    for HASHLAYER in ${layers_dl}; do
+ 	hashtype=${HASHLAYER%:*}
+ 	layer=${HASHLAYER#*:}
+ 	hashtype_aria=$(echo ${hashtype} | sed 's/^\([a-z]*\)\([0-9]*\)$/\1-\2/')
+ 	echo ${reg_uri_blobs}/${HASHLAYER}
+ 	echo "  checksum=${hashtype_aria}=${layer}"
+ 	echo "  out=${HASHLAYER}.tar.gz"
+    done | aria2c -i - -d ${cachedir} --header="Authorization: Bearer ${token}" -V
+fi
 
 ##############################################
 # Extract and Clean

--- a/dockerhub2oci
+++ b/dockerhub2oci
@@ -150,7 +150,7 @@ if [ "${strip_headers}" == true ]; then
         hashtype_aria=$(echo ${hashtype} | sed 's/^\([a-z]*\)\([0-9]*\)$/\1-\2/')
 
         # Decide on the final uri (with or without Auth, and
- 	hashlayer_final_uri=${reg_uri_blobs}/${HASHLAYER}
+        hashlayer_final_uri=${reg_uri_blobs}/${HASHLAYER}
         hashlayer_final_uri=$(curl -H "Authorization: Bearer ${token}" -Ls -o /dev/null -w %{url_effective} --max-filesize 1024 ${reg_uri_blobs}/${HASHLAYER})
         echo ${hashlayer_final_uri}
         echo "  checksum=${hashtype_aria}=${layer}"

--- a/ngc2oci
+++ b/ngc2oci
@@ -46,7 +46,7 @@ image="tensorflow"
 tag="17.10"
 cmd=""
 
-cachedir=${TMPDIR:-/tmp}/ngc2oci/
+cachedir=${TMPDIR:-/tmp}/ngc2oci
 
 writable_dirs=false
 
@@ -88,7 +88,7 @@ while true ; do
 done
 
 # Put command together to pass on to dockerhub2oci
-cmd="--registry nvcr.io $cmd --repo $repo --image $image --tag $tag";
+cmd="--registry nvcr.io $cmd --repo $repo --image $image --tag $tag --strip-headers";
 
 img_full="${repo}/${image}"
 auth_uri="https://authn.nvidia.com/token"

--- a/ngc2oci
+++ b/ngc2oci
@@ -92,7 +92,7 @@ done
 
 img_full="${repo}/${image}"
 auth_uri="https://authn.nvidia.com/token"
-auth_uri_full="${auth_uri}?service=registry&scope=repository:${img_full}:pull"
+auth_uri_full="${auth_uri}?service=registry&expires_in=900&scope=repository:${img_full}:pull"
 
 # If nvidia is desired, a --token is required!
 if [ "${token}" == "unset" ]; then
@@ -101,12 +101,15 @@ if [ "${token}" == "unset" ]; then
 fi
 
 # The nvidia cloud token still needs to be converted to base64
-# This isn't working yet
 
-token="$(echo -n "\$oauthtoken:$token" | base64)"
-token=$(curl -s -H "Authorization: Basic ${token}" ${auth_uri_full} | jq -r .token)
+token="$(echo -n "\$oauthtoken:$token" | base64)" | tr -d " "
+token=$(curl -s -H "Authorization: Basic ${token}" -H "Content-Type: application/json; charset=utf-8" -H "Accept: application/json" ${auth_uri_full} | jq -r .token)
 echo $token
 
+# response I'm getting
+# {"timestamp":1522964755796,"status":401,"error":"Unauthorized","message":"Unauthorized","path":"/token"}
+
 echo "exec ${HERE}/dockerhub2oci --token ${token} $cmd"
+
 # Then call dockerhub2oci
 #exec "${HERE}/dockerhub2oci" --token ${token} $cmd

--- a/ngc2oci
+++ b/ngc2oci
@@ -23,7 +23,7 @@ Tool to pull an image from an Nvidia Cloud registry and extract the contents
 to a folder to be used as OCI image.
 
 Example usage:
-$0 --repo tensorflow --image tensorflow --tag 17.10 --token $token
+$0 --repo tensorflow --image tensorflow --tag 17.10 --oauthtoken $token
 EOF
 exit 1
 }
@@ -41,42 +41,39 @@ fi
 
 registry="nvcr.io"
 repo="nvidia"
-token="unset"
+oauthtoken="unset"
 image="tensorflow"
 tag="17.10"
+cmd=""
 
 cachedir=${TMPDIR:-/tmp}/ngc2oci/
 
 writable_dirs=false
-cmd="--registry nvcr.io"
 
-TEMP=$(getopt -o h --long repo:,image:,tag:,token:,cachedir:,writable-dirs,help -n $0 -- "$@")
-if [ $? != 0 ] ; then printHelp; exit 1; fi
+TEMP=$(getopt -o h --long repo:,image:,tag:,oauthtoken:,cachedir:,writable-dirs,help -n $0 -- "$@")
+if [ $? != 0 ] ; then usage; exit 1; fi
 eval set -- "$TEMP"
 while true ; do
 	case "$1" in
 		--repo)          
                       repo=$2;            
                       shift 2;
-                      cmd="$cmd --repo $repo";
                 ;;
 		--image)         
                       image=$2;           
                       shift 2;
-                      cmd="$cmd --image $image";
                 ;;
 		--tag)           
                       tag=$2;             
                       shift 2;
-                      cmd="$cmd --tag $tag";
                 ;;
 		--cachedir)      
                       cachedir=$2;
                       shift 2;
                       cmd="$cmd --cachedir $cachedir";
                 ;;
-		--token)         
-                      token=$2;           
+		--oauthtoken)   
+                      oauthtoken=$2;           
                       shift 2;
                 ;;
 		--writable-dirs) 
@@ -90,26 +87,25 @@ while true ; do
 	esac
 done
 
+# Put command together to pass on to dockerhub2oci
+cmd="--registry nvcr.io $cmd --repo $repo --image $image --tag $tag";
+
 img_full="${repo}/${image}"
 auth_uri="https://authn.nvidia.com/token"
 auth_uri_full="${auth_uri}?service=registry&expires_in=900&scope=repository:${img_full}:pull"
 
 # If nvidia is desired, a --token is required!
-if [ "${token}" == "unset" ]; then
+if [ "${oauthtoken}" == "unset" ]; then
     echo "You must provide an Nvidia Cloud token with --token"
     exit 1
 fi
 
 # The nvidia cloud token still needs to be converted to base64
 
-token="$(echo -n "\$oauthtoken:$token" | base64)" | tr -d " "
+token=$(echo -n "\$oauthtoken:$oauthtoken" | base64 -w 0 | tr -d " ")
 token=$(curl -s -H "Authorization: Basic ${token}" -H "Content-Type: application/json; charset=utf-8" -H "Accept: application/json" ${auth_uri_full} | jq -r .token)
-echo $token
-
-# response I'm getting
-# {"timestamp":1522964755796,"status":401,"error":"Unauthorized","message":"Unauthorized","path":"/token"}
-
-echo "exec ${HERE}/dockerhub2oci --token ${token} $cmd"
 
 # Then call dockerhub2oci
-#exec "${HERE}/dockerhub2oci" --token ${token} $cmd
+echo $cmd
+export DOCKERHUB2OCI_TOKEN=$token
+exec ${HERE}/dockerhub2oci $cmd

--- a/ngc2oci
+++ b/ngc2oci
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+#
+# ngc2oci - Simple shell tool to pull from Nvidia Cloud and create an OCI image.
+# Copyright (C) 2018  Vanessa Sochat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+function help() {
+cat <<EOF
+Tool to pull an image from an Nvidia Cloud registry and extract the contents
+to a folder to be used as OCI image.
+
+Example usage:
+$0 --repo tensorflow --image tensorflow --tag 17.10 --token $token
+EOF
+exit 1
+}
+
+# Ensure functions available
+
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ ! -f "${HERE}/dockerhub2oci" ]; then
+    echo "Cannot find dockerhub2oci, exiting."
+    exit 1
+fi
+
+# Defaults
+
+registry="nvcr.io"
+repo="nvidia"
+token="unset"
+image="tensorflow"
+tag="17.10"
+
+cachedir=${TMPDIR:-/tmp}/ngc2oci/
+
+writable_dirs=false
+cmd="--registry nvcr.io"
+
+TEMP=$(getopt -o h --long repo:,image:,tag:,token:,cachedir:,writable-dirs,help -n $0 -- "$@")
+if [ $? != 0 ] ; then printHelp; exit 1; fi
+eval set -- "$TEMP"
+while true ; do
+	case "$1" in
+		--repo)          
+                      repo=$2;            
+                      shift 2;
+                      cmd="$cmd --repo $repo";
+                ;;
+		--image)         
+                      image=$2;           
+                      shift 2;
+                      cmd="$cmd --image $image";
+                ;;
+		--tag)           
+                      tag=$2;             
+                      shift 2;
+                      cmd="$cmd --tag $tag";
+                ;;
+		--cachedir)      
+                      cachedir=$2;
+                      shift 2;
+                      cmd="$cmd --cachedir $cachedir";
+                ;;
+		--token)         
+                      token=$2;           
+                      shift 2;
+                ;;
+		--writable-dirs) 
+                      writable_dirs=true;
+                      shift 1;
+                      cmd="$cmd --writable_dirs";
+                ;;
+		-h|--help)       help;               exit 0;;
+		--)              shift;              break;;
+		*) echo "Internal error!";           exit 1;;
+	esac
+done
+
+img_full="${repo}/${image}"
+auth_uri="https://authn.nvidia.com/token"
+auth_uri_full="${auth_uri}?service=registry&scope=repository:${img_full}:pull"
+
+# If nvidia is desired, a --token is required!
+if [ "${token}" == "unset" ]; then
+    echo "You must provide an Nvidia Cloud token with --token"
+    exit 1
+fi
+
+# The nvidia cloud token still needs to be converted to base64
+# This isn't working yet
+
+token="$(echo -n "\$oauthtoken:$token" | base64)"
+token=$(curl -s -H "Authorization: Basic ${token}" ${auth_uri_full} | jq -r .token)
+echo $token
+
+echo "exec ${HERE}/dockerhub2oci --token ${token} $cmd"
+# Then call dockerhub2oci
+#exec "${HERE}/dockerhub2oci" --token ${token} $cmd


### PR DESCRIPTION
Hey @olifre ! This pull request will close #4 and does the following:

 - adds a variable to optionally specify the registry, with default still being Docker Hub. This of course does not handle authentication and dealing with username / password, but likely this can be another feature added if someone comes along that needs it. I didn't need it for this small bit of work.
 - Adds a new script, blob2oci, that reduces the functionality to just extract an archive to a destination folder, and handling the whiteout files. The use case here is that I have an application that is handling the registry requests, and then downloading the layers, and I want to issue the command for each layer from the application. Once I have a folder extracted I can use Singularity to build from it.

I'm so grateful for this script because of the recent security issues with Singularity, they were forced to remove the newly added whiteout handling because of libarchive. With this script I'm able to take an approach where separate components (python, blob2oci, and then Singularity) handle just the pieces they are optimized for.

I have a quick question! I noticed that the docker2oci flags an archive as malicious given that a link from a file is outside the tree. this part:

```
			# Ensure this is below our tree
			case $(readlink -f "${to_be_deleted}") in
				$(readlink -f .)/*)
					rm -rf "${to_be_deleted}";;
				*)
					echo "ERROR!";
					echo "File ${to_be_deleted} is not below extracted tree!";
					echo "This looks malicious, exiting now!";
					exit 1;;
			esac
```
We of course wouldn't want to delete it, but do we want to exit and say it's malicious? Wouldn't this be a likely case given that the docker image was linked to external things? It's not totally containerized, but you know how it is.

Again, huge thanks! I'm working really hard on this application, and it wouldn't be possible without this little bit of magic :)

I agree that my changes can be licensed under GPL 3.